### PR TITLE
Removed use of deprecated createCredentials() method if run under nod…

### DIFF
--- a/lib/starttls.js
+++ b/lib/starttls.js
@@ -43,7 +43,11 @@ function starttls(socket, options, callback, isServer) {
     opts.ciphers = RECOMMENDED_CIPHERS;
 
   socket.removeAllListeners("data");
-  sslcontext = crypto.createCredentials(opts);
+  if (tls.createSecureContext) {
+    sslcontext = tls.createSecureContext(opts);
+  } else {
+    sslcontext = crypto.createCredentials(opts);
+  }
   pair = tls.createSecurePair(sslcontext, isServer);
   cleartext = pipe(pair, socket);
 


### PR DESCRIPTION
I added an if-statement so that it works under both Node 0.10 and 0.11+.  Node 0.11+ will generate a warning on the console when createCredentials() is called.

This fixes issue #50 