### PR TITLE
Check for error 'code' as opposed to 'errno'

### DIFF
--- a/lib/glob.js
+++ b/lib/glob.js
@@ -1,6 +1,5 @@
 var PathModule = require('path'),
-    events = require('events'),
-    constants = require('constants');
+    events = require('events');
 
 var CONC = 5;
 function setMaxStatsAtOnce(n) {
@@ -92,7 +91,7 @@ function glob(path, fsm, callback, noWildcards) {
   if (w == path.length) { // There are no wildcards.
     fsm.readdir(path, function(err, contents) {
       if (err) {
-        if (err.errno == constants.ENOTDIR) {
+        if (err.code === 'ENOTDIR') {
           statList(fsm, [path], function(err, list) {
             if (err)
               return callback(err);
@@ -101,7 +100,7 @@ function glob(path, fsm, callback, noWildcards) {
             callback(null, list);
           });
         }
-        else if (err.errno == constants.ENOENT) {
+        else if (err.code === 'ENOENT') {
           callback(null, []);
         }
         else {
@@ -156,7 +155,7 @@ function glob(path, fsm, callback, noWildcards) {
     function readTheDir(listingSingleDir) {
       fsm.readdir(base, function(err, contents) {
         if (err) {
-          if (err.errno == constants.ENOTDIR || err.errno == constants.ENOENT) {
+          if (err.code === 'ENOTDIR' || err.code === 'ENOENT') {
             callback(null, []);
           }
           else {

--- a/test/list.js
+++ b/test/list.js
@@ -25,8 +25,21 @@ describe('LIST command', function () {
     });
   });
 
+  it('should list single files', function (done) {
+    client.list('/data.txt', function (error, fileListing) {
+      common.should(error).not.be.ok;
+      fileListing = fileListing
+        .split('\r\n')
+        .filter(function (line) {
+          return line.indexOf(' data.txt') !== -1;
+        });
+      fileListing.should.have.lengthOf(1);
+      fileListing[0].should.startWith('-');
+      done();
+    });
+  });
+
   afterEach(function () {
     server.close();
   });
 });
-


### PR DESCRIPTION
I noticed that running LIST on a specific file didn't work.

RFC 959 implies that this should work...
> If the pathname specifies a file then the server should send current information on the file.

I ran the following code on two platforms:

```
var os = require('os');
console.log(os.platform() + ' ' + os.release());

var fs = require('fs');
fs.readdir('app.js', function(err) {
  console.log('err: ', err);
    
  var constants = require('constants');
  console.log('ENOTDIR is: ', constants.ENOTDIR);
});
```

On Windows:
```
win32 10.0.10586
err:  { [Error: ENOTDIR: not a directory, scandir 'c:\workspace\nodeftpd\app.js']
errno: -4052,
code: 'ENOTDIR',
syscall: 'scandir',
path: 'c:\\workspace\\nodeftpd\\app.js' }
ENOTDIR is:  20
```

On Linux:
```
linux 3.13.0-66-generic
err:  { [Error: ENOTDIR, readdir 'app.js'] errno: 27, code: 'ENOTDIR', path: 'app.js' }
ENOTDIR is:  20
```

Note that ```errno``` is different.

There's not much in the way of documentation and best practices, but I found [this](https://www.joyent.com/developers/node/design/errors), which, at the very bottom, says:

> errno
the symbolic value of errno (e.g., "ENOENT"). 
Do not use this for errors that don't actually set the C value of errno. 
Use "name" to distinguish between types of errors.