### PR TITLE
Set the userFsModule earlier so it can be used in getInitialCwd or getRoot

### DIFF
--- a/lib/ftpd.js
+++ b/lib/ftpd.js
@@ -1516,7 +1516,6 @@ FtpConnection.prototype._command_PASS = function (password) {
           function setCwd(cwd) {
             function setRoot(root) {
               self.root = root;
-              self.fs = userFsModule || fsModule;
               self.respond('230 User logged in, proceed.');
             }
 
@@ -1536,6 +1535,7 @@ FtpConnection.prototype._command_PASS = function (password) {
             }
           }
           self.username = username;
+          self.fs = userFsModule || fsModule;
           if (self.server.getInitialCwd.length <= 1) {
             setCwd(withCwd(self.server.getInitialCwd(self)));
           }


### PR DESCRIPTION
Since `self` is passed into `getInitialCwd` and `getRoot`, bind `self.fs` earlier in case the user has supplied a custom FileSystem abstraction and would like to perform some bootstrapping in those functions.