### PR TITLE
Add `hideDotFiles` option to hide files beginning with a dot

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ The user is not able to escape this directory.
     - Determines the maximum file size (in bytes) for which uploads are buffered in memory before being written to disk.
     - Has an effect only if `useWriteFile` is set to `true`.
     - If `uploadMaxSlurpSize` is not set, then there is no limit on buffer size.
+- `hideDotFiles`: _(default: false)_
+    - Hides files beginning with a dot (UNIX hidden files) on `LIST` commands.
 - `maxStatsAtOnce`: _(default: 5)_
     - The maximum number of concurrent calls to `fs.stat` which will be
   made when processing a `LIST` request.

--- a/lib/ftpd.js
+++ b/lib/ftpd.js
@@ -629,6 +629,13 @@ FtpConnection.prototype._LIST = function(commandArg, detailed, cmd) {
       return;
     }
 
+    if (self.server.options.hideDotFiles) {
+      files = files.filter(function(file) {
+        if (file.name && file.name[0] !== '.')
+          return true;
+      });
+    }
+
     self._logIf(3, "Directory has " + files.length + " files");
     if (files.length == 0)
       return self._listFiles([], detailed, cmd);


### PR DESCRIPTION
This option is useful when working on UNIX systems where dot files are hidden. There may be cases in which we may want normal files only to be listed (not hidden).

Cheers!