### PR TITLE
Add a test for file paths with unusual characters in them.

### DIFF
--- a/fixture/jose/tricky_paths/b\\s\l, ""q'u"o"te''; pi|p|e & ^up^/b\\s\l, ""q'u"o"te''; pi|p|e & ^up^.txt
+++ b/fixture/jose/tricky_paths/b\\s\l, ""q'u"o"te''; pi|p|e & ^up^/b\\s\l, ""q'u"o"te''; pi|p|e & ^up^.txt
@@ -1,0 +1,2 @@
+good 😎
+filesystem.

--- a/fixture/jose/tricky_paths/b\\s\l, ""q'u"o"te''; pi|p|e & ^up^/cool-glasses.😎.txt
+++ b/fixture/jose/tricky_paths/b\\s\l, ""q'u"o"te''; pi|p|e & ^up^/cool-glasses.😎.txt
@@ -1,0 +1,2 @@
+good 😎
+filesystem.

--- a/lib/ftpd.js
+++ b/lib/ftpd.js
@@ -25,6 +25,9 @@ var starttls = require('./starttls');
  */
 
 function pathEscape(text) {
+  // Rules for quoting: RFC 959 -> Appendix II -> Directory Commands
+  // (http://www.w3.org/Protocols/rfc959/A2_DirectoryCommands.html)
+  // -> Reply Codes -> search for "embedded double-quotes"
   text = text.replace(/\"/g, '""');
   return text;
 }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "devDependencies": {
     "async": "~0.1.15",
+    "collect-stream": "^1.1.1",
     "mocha": "~1.17.1",
     "should": "~3.1.2",
     "jsftp": "git://github.com/sergi/jsftp.git#master",

--- a/test/tricky_paths.js
+++ b/test/tricky_paths.js
@@ -1,0 +1,82 @@
+﻿/*jslint indent: 2, maxlen: 80, node: true */
+/*globals describe, it, beforeEach, afterEach */
+'use strict';
+
+var common = require('./common');
+var async = require('async');
+var collectStream = require('collect-stream');
+
+describe('RETR command', function () {
+  var client,
+    server;
+
+  //run tests both ways
+  [true, false].forEach(function (useReadFile) {
+
+    describe('with useReadFile = ' + useReadFile, function () {
+
+      beforeEach(function (done) {
+        server = common.server({ useReadFile: useReadFile });
+        client = common.client(done);
+      });
+
+      it('should cope with unusual paths', function (done) {
+        var coolGlasses = '\uD83D\uDE0E',
+          trickyName = "b\\\\s\\l, \"\"q'u\"o\"te''; pi|p|e & ^up^",
+          dirPath = 'tricky_paths/' + trickyName,
+          expectedData = 'good ' + coolGlasses + '\nfilesystem.\n';
+
+        function receive_and_compare(socket, nxt) {
+          collectStream(socket, function (error, receivedData) {
+            common.should.not.exist(error);
+            String(receivedData).should.eql(expectedData);
+            nxt();
+          });
+          socket.resume();
+        }
+
+        async.waterfall([
+          function strange_path_redundant_escape(nxt) {
+            var dirRfcQuoted = dirPath.replace(/"/g, '""');
+            client.raw('CWD', dirRfcQuoted, function (error) {
+              common.should.exist(error);
+              error.code.should.equal(550);
+              nxt();
+            });
+          },
+          function strange_path_cwd(nxt) {
+            client.raw('CWD', dirPath, nxt);
+          },
+          function check_response(response, nxt) {
+            response.code.should.equal(250);
+            if (response.code !== 250) {
+              return nxt(new Error('failed to CWD to unusual path'));
+            }
+            nxt();
+          },
+          function strange_path_retr(nxt) {
+            var filename = trickyName + '.txt';
+            client.get(filename, nxt);
+          },
+          receive_and_compare,
+          function strange_path_retr(nxt) {
+            var filename = 'cool-glasses.' + coolGlasses + '.txt';
+            client.get(filename, nxt);
+          },
+          receive_and_compare,
+        ], function finished(error) {
+          common.should.not.exist(error);
+          done();
+        });
+      });
+
+      afterEach(function () {
+        server.close();
+      });
+
+    });
+
+  });
+
+
+});


### PR DESCRIPTION
In case I included characters that are invalid by RFC or similar rulesets, let's instead make `ftpd` reply with an error message, and add a note in the source which rule would be violated by that character.