### PR TITLE
APPE command

### DIFF
--- a/fixture/jose/uploads/.gitignore
+++ b/fixture/jose/uploads/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/lib/ftpd.js
+++ b/lib/ftpd.js
@@ -1349,17 +1349,17 @@ FtpConnection.prototype._command_STOR = function(commandArg) {
   var filename = withCwd(this.cwd, commandArg);
 
   if (this.server.options.useWriteFile) {
-    this._STOR_usingWriteFile(filename);
+    this._STOR_usingWriteFile(filename, 'w');
   } else {
-    this._STOR_usingCreateWriteStream(filename);
+    this._STOR_usingCreateWriteStream(filename, null, 'w');
   }
 };
 
 // 'initialBuffers' argument is set when this is called from _STOR_usingWriteFile.
-FtpConnection.prototype._STOR_usingCreateWriteStream = function(filename, initialBuffers) {
+FtpConnection.prototype._STOR_usingCreateWriteStream = function(filename, initialBuffers, flag) {
   var self = this;
 
-  var wStreamFlags = {flags: 'w', mode: 0644};
+  var wStreamFlags = {flags: flag || 'w', mode: 0644};
   var storeStream = self.fs.createWriteStream(pathModule.join(self.root, filename), wStreamFlags);
   var notErr = true;
   // Adding for event metadata for file upload (STOR)
@@ -1453,7 +1453,7 @@ FtpConnection.prototype._STOR_usingCreateWriteStream = function(filename, initia
   }
 };
 
-FtpConnection.prototype._STOR_usingWriteFile = function(filename) {
+FtpConnection.prototype._STOR_usingWriteFile = function(filename, flag) {
   var self = this;
 
   var erroredOut = false;
@@ -1520,9 +1520,10 @@ FtpConnection.prototype._STOR_usingWriteFile = function(filename) {
       return;
     }
 
+    var wOptions = {flag: flag || 'w', mode: 0644};
     var contents = {filename: filename, data: slurpBuf.slice(0, totalBytes)};
     self.emit('file:stor:contents', contents);
-    self.fs.writeFile(pathModule.join(self.root, filename), contents.data, function(err) {
+    self.fs.writeFile(pathModule.join(self.root, filename), contents.data, wOptions, function(err) {
       self.emit('file:stor', 'close', {
         user: self.username,
         file: filename,
@@ -1551,6 +1552,16 @@ FtpConnection.prototype._STOR_usingWriteFile = function(filename) {
 
   function errorHandler() {
     erroredOut = true;
+  }
+};
+
+FtpConnection.prototype._command_APPE = function(commandArg) {
+  var filename = withCwd(this.cwd, commandArg);
+
+  if (this.server.options.useWriteFile) {
+    this._STOR_usingWriteFile(filename, 'a');
+  } else {
+    this._STOR_usingCreateWriteStream(filename, null, 'a');
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "istanbul": "~0.2.4",
     "jsftp": "git://github.com/sergi/jsftp.git#master",
     "mocha": "^2.3.4",
-    "should": "~3.1.2"
+    "should": "~3.1.2",
+    "ftp": "^0.3.10"
   }
 }

--- a/test/appe.js
+++ b/test/appe.js
@@ -1,0 +1,53 @@
+var common = require('./lib/common');
+var FtpClient = require('ftp');
+var path = require('path');
+var fs = require('fs');
+
+describe('APPE command', function() {
+  'use strict';
+
+  var client = new FtpClient();
+  var server;
+
+  //run tests both ways
+  [true, false].forEach(function(useWriteFile) {
+
+    describe('with useWriteFile = ' + useWriteFile, function() {
+
+      beforeEach(function(done) {
+        server = common.server({useWriteFile:useWriteFile});
+        client.once('ready', function() {
+          done();
+        });
+        client.connect({
+          host: common.defaultOptions().host,
+          port: common.defaultOptions().port,
+          user: common.defaultOptions().user,
+          password: common.defaultOptions().pass,
+        });
+      });
+
+      it('should append data to existing file', function(done) {
+        var basename = path.basename(__filename);
+        var fileSize = fs.statSync(__filename).size;
+        client.put(__filename, '/uploads/' + basename, function(err) {
+          common.should.not.exist(err);
+          client.append(__filename, '/uploads/' + basename, function(err) {
+            common.should.not.exist(err);
+            var newSize = fs.statSync(path.join(common.fixturesPath(), common.defaultOptions().user, 'uploads', basename)).size;
+            newSize.should.be.eql(fileSize * 2);
+            done();
+          });
+        });
+      });
+
+      afterEach(function() {
+        server.close();
+      });
+
+    });
+
+  });
+
+
+});

--- a/test/lib/common.js
+++ b/test/lib/common.js
@@ -49,6 +49,10 @@ var common = module.exports = {
     return fixturesPath;
   },
 
+  defaultOptions: function() {
+    return options;
+  },
+
   server: function(customOptions) {
     customOptions = customOptions || {};
     Object.keys(options).forEach(function(key) {


### PR DESCRIPTION
Add APPE (append) command.

Unfortunately I can't write a test for it because jsftp doesn't support APPE. And the other library I tried which supports append (https://github.com/mscdex/node-ftp) doesn't support UTF8...

How about we use mscdex/node-ftp only for this test? Means another dependancy.