### PR TITLE
Eslint - ignore files in /fixture

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 _*
 node_modules/
+fixture/


### PR DESCRIPTION
The APPE command test uploads itself as __filename to /fixture and this can cause `eslint` to fail. This PR adds /fixture to .eslintignore file.