### PR TITLE
Change `filesize` event property to `bytesRead` or `bytesWritten`

### DIFF
--- a/lib/FtpConnection.js
+++ b/lib/FtpConnection.js
@@ -946,7 +946,9 @@ FtpConnection.prototype._RETR_usingCreateReadStream = function(commandArg, filen
             self.emit('file:retr', 'close', {
               user: self.username,
               file: filename,
+              /** @deprecated filesize is deprecated, use bytesRead/bytesWritten instead */
               filesize: 0,
+              bytesRead: rs.bytesRead,
               sTime: startTime,
               eTime: now,
               duration: now - startTime,
@@ -964,7 +966,9 @@ FtpConnection.prototype._RETR_usingCreateReadStream = function(commandArg, filen
             self.emit('file:retr', 'close', {
               user: self.username,
               file: filename,
+              /** @deprecated filesize is deprecated, use bytesRead/bytesWritten instead */
               filesize: 0,
+              bytesRead: rs.bytesRead,
               sTime: startTime,
               eTime: now,
               duration: now - startTime,
@@ -1000,7 +1004,9 @@ FtpConnection.prototype._RETR_usingReadFile = function(commandArg, filename) {
       self.emit('file:retr', 'error', {
         user: self.username,
         file: filename,
+        /** @deprecated filesize is deprecated, use bytesRead/bytesWritten instead */
         filesize: 0,
+        bytesRead: 0,
         sTime: startTime,
         eTime: new Date(),
         duration: new Date() - startTime,
@@ -1025,7 +1031,9 @@ FtpConnection.prototype._RETR_usingReadFile = function(commandArg, filename) {
           self.emit('file:retr', 'close', {
             user: self.username,
             file: filename,
+            /** @deprecated filesize is deprecated, use bytesRead/bytesWritten instead */
             filesize: contentLength,
+            bytesRead: contentLength,
             sTime: startTime,
             eTime: new Date(),
             duration: new Date() - startTime,
@@ -1118,7 +1126,6 @@ FtpConnection.prototype._STOR_usingCreateWriteStream = function(filename, initia
   var notErr = true;
   // Adding for event metadata for file upload (STOR)
   var startTime = new Date();
-  var uploadSize = 0;
 
   if (initialBuffers) {
     //todo: handle back-pressure
@@ -1146,7 +1153,9 @@ FtpConnection.prototype._STOR_usingCreateWriteStream = function(filename, initia
     self.emit('file:stor', 'error', {
       user: self.username,
       file: filename,
-      filesize: uploadSize,
+      /** @deprecated filesize is deprecated, use bytesRead/bytesWritten instead */
+      filesize: 0,
+      bytesWritten: storeStream.bytesWritten,
       sTime: startTime,
       eTime: new Date(),
       duration: new Date() - startTime,
@@ -1165,7 +1174,9 @@ FtpConnection.prototype._STOR_usingCreateWriteStream = function(filename, initia
     self.emit('file:stor', 'close', {
       user: self.username,
       file: filename,
-      filesize: uploadSize,
+      /** @deprecated filesize is deprecated, use bytesRead/bytesWritten instead */
+      filesize: 0,
+      bytesWritten: storeStream.bytesWritten,
       sTime: startTime,
       eTime: new Date(),
       duration: new Date() - startTime,
@@ -1281,7 +1292,9 @@ FtpConnection.prototype._STOR_usingWriteFile = function(filename, flag) {
       self.emit('file:stor', 'close', {
         user: self.username,
         file: filename,
+        /** @deprecated filesize is deprecated, use bytesRead/bytesWritten instead */
         filesize: totalBytes,
+        bytesWritten: totalBytes,
         sTime: startTime,
         eTime: new Date(),
         duration: new Date() - startTime,


### PR DESCRIPTION
How about to remove `filesize` property from `stor` and `retr` events (which is almost always zero btw) and instead provide more suitable `bytesRead` and `bytesWritten` properties?