### PR TITLE
host and port are declared within an if statement

### DIFF
--- a/lib/FtpConnection.js
+++ b/lib/FtpConnection.js
@@ -664,7 +664,7 @@ FtpConnection.prototype._command_EPRT = function(x, y) {
 
 FtpConnection.prototype._PORT = function(commandArg, command) {
   var self = this;
-  var m;
+  var m, host, port;
 
   self.dataConfigured = false;
 
@@ -675,8 +675,8 @@ FtpConnection.prototype._PORT = function(commandArg, command) {
       return;
     }
 
-    var host = m[1] + '.' + m[2] + '.' + m[3] + '.' + m[4];
-    var port = (parseInt(m[5], 10) << 8) + parseInt(m[6], 10);
+    host = m[1] + '.' + m[2] + '.' + m[3] + '.' + m[4];
+    port = (parseInt(m[5], 10) << 8) + parseInt(m[6], 10);
     if (isNaN(port)) {
       // The value should never be NaN because the relevant groups in the regex matche 1-3 digits.
       throw new Error('Impossible NaN in FtpConnection.prototype._PORT');

--- a/lib/FtpConnection.js
+++ b/lib/FtpConnection.js
@@ -664,7 +664,9 @@ FtpConnection.prototype._command_EPRT = function(x, y) {
 
 FtpConnection.prototype._PORT = function(commandArg, command) {
   var self = this;
-  var m, host, port;
+  var m;
+  var host;
+  var port;
 
   self.dataConfigured = false;
 


### PR DESCRIPTION
host and port are declared within an if statement and are then used outside of scope. Moved the declaration of host and port outside of the inner scope to ensure that they are defined for all cases