### PR TITLE
Port numbers are not verified in PORT. Switching from passive to active will cause hung transfers

### DIFF
--- a/lib/FtpConnection.js
+++ b/lib/FtpConnection.js
@@ -669,6 +669,7 @@ FtpConnection.prototype._PORT = function(commandArg, command) {
   var port;
 
   self.dataConfigured = false;
+  self._closeDataConnections();
 
   if (command === 'PORT') {
     m = commandArg.match(/^([0-9]{1,3}),([0-9]{1,3}),([0-9]{1,3}),([0-9]{1,3}),([0-9]{1,3}),([0-9]{1,3})$/);

--- a/lib/FtpConnection.js
+++ b/lib/FtpConnection.js
@@ -703,13 +703,14 @@ FtpConnection.prototype._PORT = function(commandArg, command) {
       // The value should never be NaN because the relevant group in the regex matches 1-5 digits.
       throw new Error('Impossible NaN in FtpConnection.prototype._PORT (2)');
     }
-    if (r > 65535 || r <= 0) {
-      self.respond('501 Bad argument to EPRT (invalid port number)');
-      return;
-    }
 
     host = m[1];
     port = r;
+  }
+
+  if (port > 65535 || port < 1024) {
+    self.respond('501 Bad argument to ' + command + ' (invalid port number)');
+    return;
   }
 
   self.dataConfigured = true;


### PR DESCRIPTION
- Verify port number for PORT. 
- Don't allow active connections to ports under 1024.
- Close passive datasocket when an active transfer is requested
If a client first performed a passive transfer and then switched to active the connection would hang waiting for a connection to the passive port.


