### PR TITLE
Check socket is not null

### DIFF
--- a/lib/FtpConnection.js
+++ b/lib/FtpConnection.js
@@ -47,7 +47,7 @@ FtpConnection.prototype._logIf = function(verbosity, message) {
 // also don't want to explicitly specify ASCII encoding for every call to 'write'
 // with a string argument.
 FtpConnection.prototype._writeText = function(socket, data, callback) {
-  if (!socket.writable) {
+  if (!socket || !socket.writable) {
     this._logIf(LOG.DEBUG, 'Attempted writing to a closed socket:\n>> ' + data.trim());
     return;
   }


### PR DESCRIPTION
This can happen when connection is lost (`end` event received, not `error`) during file upload,
then `_onClose` might be called before storeStream.on('finish')