### PR TITLE
Standardize Path Names for readdir

### DIFF
--- a/lib/glob.js
+++ b/lib/glob.js
@@ -84,6 +84,9 @@ function matchPattern(pattern, string) {
 }
 
 function glob(path, fsm, callback, noWildcards) {
+  // Standardize path for wildcard lookup
+  path = path.replace(/\\/gi, '/')
+  
   var w;
   for (w = 0; !noWildcards && w < path.length && path.charAt(w) !== '*' && path.charAt(w) !== '?'; ++w) {
 


### PR DESCRIPTION
Different clients will use different characters for path delimiting (e.g. the Windows command line FTP client uses \ instead of /).Standardize on / to ease wildcard lookup.