### PR TITLE
Update README.md on createWriteStream requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,9 @@ The following must be implemented:
     - specific object properties: `{ mode, isDirectory(), size, mtime }`
 - if `useWriteFile` option is not set or is false
     - `createWriteStream`: _Returns a writable stream, requiring:_
-        - events: 'open', 'error', 'close'
-        - functions: 'write'
+        - events: 'open', 'error', 'finish'
+        - functions: 'write', 'end'
+        - properties: 'bytesWritten'
 - if `useWriteFile` option is set to 'true'
     - `writeFile`
 - if `useReadFile` option is not set or is false


### PR DESCRIPTION
According to https://github.com/sstur/nodeftpd/blob/master/lib/FtpConnection.js#L1127, `createWriteStream` use more than those functions listed in README.md.

I am updating the list.