### PR TITLE
Ensuring to forward the finish event from TLS socket

### DIFF
--- a/lib/starttls.js
+++ b/lib/starttls.js
@@ -124,7 +124,7 @@ function pipe(pair, socket) {
     }
   }
 
-  var map = forwardEvents(['timeout', 'end', 'close', 'drain', 'error'], socket, cleartext);
+  var map = forwardEvents(['timeout', 'end', 'close', 'drain', 'error', 'finish'], socket, cleartext);
 
   function onclose() {
     socket.removeListener('error', onerror);


### PR DESCRIPTION
@sstur Hopefully it's self explanatory what's going on … the write stream requires the finish event to know that it needs to stop listening for chunks (and without it the upload hangs until timeout after sending all the data).

I didn't write any tests for it as it doesn't appear there are any for TLS (or even for the write streams generally?). Happy to contribute one if you feel this would make it easier to accept (though would probably take a bit of time as there's a lot of stubbing to do to get it to a stage where a test would work). 