### PR TITLE
Double response when upload fails due to file write stream error

### DIFF
--- a/lib/FtpConnection.js
+++ b/lib/FtpConnection.js
@@ -1163,8 +1163,8 @@ FtpConnection.prototype._STOR_usingCreateWriteStream = function(filename, initia
       duration: new Date() - startTime,
       errorState: !notErr,
     });
-    storeStream.end();
     notErr = false;
+    storeStream.end();
     if (self.dataSocket) {
       self._closeSocket(self.dataSocket, true);
     }


### PR DESCRIPTION
The problem is that if file write stream emits an error we call storeStream.end() before setting notErr to false, so finish event handler on file stream thinks there was no error and sends 226 reply, which makes the client to believe that upload was successful even though it failed.